### PR TITLE
resourceType instead type

### DIFF
--- a/packages/resource-jsonapi/src/interfaces/resource.ts
+++ b/packages/resource-jsonapi/src/interfaces/resource.ts
@@ -1,5 +1,5 @@
 export type Resource = {
     [key: string]: unknown,
-    type: string,
+    resourceType: string,
     id?: string,
 }

--- a/packages/resource-jsonapi/src/interfaces/schema.ts
+++ b/packages/resource-jsonapi/src/interfaces/schema.ts
@@ -12,7 +12,7 @@ export interface SchemaAttribute {
 
 export type Cardinality = 'has-many' | 'belongs-to';
 
-export type WithoutIdAndType<T extends Resource = Resource> = Except<T, 'type' | 'id'>;
+export type WithoutIdAndType<T extends Resource = Resource> = Except<T, 'resourceType' | 'id'>;
 
 export type SchemaAttributes<T extends Resource = Resource> = Partial<Record<StringKeyOf<WithoutIdAndType<T>>, SchemaAttribute>>;
 
@@ -26,7 +26,7 @@ export interface SchemaRelationship {
 export type SchemaRelationships<T extends Resource = Resource> = Partial<Record<StringKeyOf<WithoutIdAndType<T>>, SchemaRelationship>>;
 
 export interface ResourceSchema<T extends Resource = Resource> {
-  type: Resource['type'],
+  resourceType: Resource['resourceType'],
   attributes: SchemaAttributes<T>,
   relationships: SchemaRelationships<T>,
 }

--- a/packages/resource-jsonapi/src/serialization/document.ts
+++ b/packages/resource-jsonapi/src/serialization/document.ts
@@ -32,11 +32,11 @@ export class DocumentSerializer {
   }
 
   private serializeOneTopDocument (resource: Resource, include: IncludeQuery[]) {
-    const schema = this.registry.getSchemaFor(resource.type);
+    const schema = this.registry.getSchemaFor(resource.resourceType);
 
     const doc: JsonApiResourceObject<WithoutIdAndType<Resource>> = {
       id: resource.id,
-      type: resource.type,
+      type: resource.resourceType,
       attributes: extractSerializableAttributes(resource, attributesFromSparseFields(schema, this.query.fields ?? {})),
       links: this.makeDocumentLinks(schema, resource),
       meta: undefined,
@@ -113,7 +113,7 @@ export class DocumentSerializer {
 
   private makeDocumentLinks (schema: ResourceSchema<Resource>, resource: Resource) {
     return {
-      self: `${this.registry.getConfig().host}/${schema.type}/${resource.id}`,
+      self: `${this.registry.getConfig().host}/${schema.resourceType}/${resource.id}`,
     };
   }
 }

--- a/packages/resource-jsonapi/src/serialization/generator/base.ts
+++ b/packages/resource-jsonapi/src/serialization/generator/base.ts
@@ -14,7 +14,7 @@ export abstract class BaseSerializerGenerator {
     const jsonApiSchema = this.baseSchemaAndWhitelist(schema);
 
     this.generateRelationships(jsonApiSchema, schema);
-    this.serializer.register(schema.type, jsonApiSchema);
+    this.serializer.register(schema.resourceType, jsonApiSchema);
   }
 
   protected generateRelationships<T extends ResourceSchema> (jsonApiSchema: JSONAPISerializer.Options, schema: T) {
@@ -29,14 +29,14 @@ export abstract class BaseSerializerGenerator {
     const relationSchema = this.registry.getSchemaFor(relationType);
 
     schema.relationships![relationName] = {
-      type: relationSchema.type,
+      type: relationSchema.resourceType,
     };
 
-    if (this.processedTypes.includes(relationSchema.type)) {
+    if (this.processedTypes.includes(relationSchema.resourceType)) {
       return;
     }
 
-    this.processedTypes.push(relationSchema.type);
+    this.processedTypes.push(relationSchema.resourceType);
     this.generate(relationSchema);
   }
 

--- a/packages/resource-jsonapi/src/utils/add-types-from-schema.ts
+++ b/packages/resource-jsonapi/src/utils/add-types-from-schema.ts
@@ -23,7 +23,7 @@ export function addResourceTypes<T extends Resource> (resources: ResourceWithout
 
 function addResourceType<T extends Resource> (resource: ResourceWithoutType<T>, discriminatorMap: DiscriminatorMap, registry: SchemaRegistries) {
   const schema = getSchemaTypeOrRejectIfUnknown(resource, discriminatorMap, registry);
-  (resource as any).type = schema.type;
+  (resource as any).type = schema.resourceType;
   for (const name of Object.keys(schema.relationships)) {
     if (resource[name] !== undefined) {
       addResourceTypes(resource[name] as T[], discriminatorMap, registry);

--- a/packages/resource-jsonapi/src/utils/attributes-from-sparse-fields.ts
+++ b/packages/resource-jsonapi/src/utils/attributes-from-sparse-fields.ts
@@ -1,7 +1,7 @@
 import type { ResourceSchema } from '../interfaces/schema.js';
 
 export function attributesFromSparseFields (schema: ResourceSchema, fields: Record<string, string[]>) {
-  return fields[schema.type]
-    ? Object.fromEntries(Object.entries(schema.attributes).filter(([name]) => fields[schema.type].includes(name)))
+  return fields[schema.resourceType]
+    ? Object.fromEntries(Object.entries(schema.attributes).filter(([name]) => fields[schema.resourceType].includes(name)))
     : schema.attributes;
 }

--- a/packages/resource-jsonapi/tests/unit/resources/deserialize.test.ts
+++ b/packages/resource-jsonapi/tests/unit/resources/deserialize.test.ts
@@ -13,7 +13,7 @@ let resourcesRegistry: ResourcesRegistryImpl;
 class ExampleSerializer {}
 
 const schemaArticle: ResourceSchema = {
-  type: 'article',
+  resourceType: 'article',
   attributes: {
     name: defaultAttribute(),
   },
@@ -23,7 +23,7 @@ const schemaArticle: ResourceSchema = {
 };
 
 const schemaUser: ResourceSchema = {
-  type: 'user',
+  resourceType: 'user',
   attributes: {
     name: defaultAttribute(),
   },

--- a/packages/resource-jsonapi/tests/unit/resources/serialization/serialize.test.ts
+++ b/packages/resource-jsonapi/tests/unit/resources/serialization/serialize.test.ts
@@ -7,7 +7,7 @@ import { JsonApiResourceSerializer } from '../../../../src/serialization/seriali
 import { defaultAttribute, defaultRelation } from '../../test-utils/default-schema-parts.js';
 
 const schema: ResourceSchema = {
-  type: 'test',
+  resourceType: 'test',
   attributes: {
     name: defaultAttribute(),
     age: defaultAttribute(),
@@ -19,7 +19,7 @@ const schema: ResourceSchema = {
 } as never;
 
 const schemaForRelationship: ResourceSchema<never> = {
-  type: 'dummy',
+  resourceType: 'dummy',
   attributes: {
     name: defaultAttribute(),
   },
@@ -47,7 +47,7 @@ describe('JsonApiResourceSerializer', () => {
 
   class TestResource {
     [key: string]: unknown;
-    type: string = 'test';
+    resourceType: string = 'test';
     id?: string;
     name!: string;
     age!: number;
@@ -56,7 +56,7 @@ describe('JsonApiResourceSerializer', () => {
 
   class DummyResource {
     [key: string]: unknown;
-    type: string = 'dummy';
+    resourceType: string = 'dummy';
     id?: string;
     declare name: string;
   }

--- a/packages/resource-jsonapi/tests/unit/utils/add-types-from-schema.test.ts
+++ b/packages/resource-jsonapi/tests/unit/utils/add-types-from-schema.test.ts
@@ -16,7 +16,7 @@ class DummyModel {
 }
 
 const fooSchema = {
-  type: 'foo',
+  resourceType: 'foo',
   relationships: {
     dummy: {
       type: 'dummy',
@@ -25,7 +25,7 @@ const fooSchema = {
 };
 
 const dummySchema = {
-  type: 'dummy',
+  resourceType: 'dummy',
   relationships: {
     foo: {
       type: 'foo',


### PR DESCRIPTION
Basically, because too many attributes are named type.